### PR TITLE
Add a GitHub Actions setting file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+on:
+  - push
+  - pull_request
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: dummy
+        run: echo 'Setting file that does nothing to run CI on pull request GH-2.'


### PR DESCRIPTION
It seems that CI does not run on pull requests unless the setting file is committed to `main` branch.

To run CI on a GitHub GH-2 pull request, first commit a setting file that does nothing.